### PR TITLE
Fix typo examples\guards\README.md   request url using HTTPie

### DIFF
--- a/websockets/chat-tcp/README.md
+++ b/websockets/chat-tcp/README.md
@@ -22,7 +22,7 @@ To start server run
 
 ```sh
 cd websockets/chat-tcp
-cargo run --bin websocket-tcp-server`
+cargo run --bin websocket-tcp-server
 ```
 
 If the current directory is not correct, the server will look for `index.html` in the wrong place.


### PR DESCRIPTION
Previous:
<img width="989" height="108" alt="Screenshot 2025-08-11 134524" src="https://github.com/user-attachments/assets/60182a04-3eba-40a1-b3e7-265239d84d0e" />

Now : 
<img width="602" height="144" alt="Screenshot 2025-08-11 134723" src="https://github.com/user-attachments/assets/1314f3a3-3ae5-4f8a-9b1d-adabe809a2ba" />

Success result:
<img width="1032" height="339" alt="Screenshot 2025-08-11 134746" src="https://github.com/user-attachments/assets/3b7747c4-9898-4200-ad86-a30ce5e35c2a" />
